### PR TITLE
docs: Corregir método clonación de repositorio

### DIFF
--- a/Guides/guideArchLinuxSpaVim.md
+++ b/Guides/guideArchLinuxSpaVim.md
@@ -1,65 +1,61 @@
 # Documentación para instalar spaVim en ArchLinux's
 >Tome este manual como un complemento para que su editor funcione correctamente, ya que puede omitirlo pero a largo o corto plazo le va a pedir dependencias o requisitos adicionales que ni usted mismo logrará encontrar, o puede que si, pero mejor instalarlos ahora mismo.
 
->Si el proceso de instalación le parece muy tedioso, **no lo instale**. Las cosas no deberían de hacersen tan complicadas, pero en ocasiones como en nuestro caso debemos sentarnos a configurar todo nuestro entorno de trabajo por complejo o simple que parezca.
-
->No se abrume por la posible "complejidad" de información que encontrará.
-
 1) **Actualizar el sistema** (Aparte de ser necesario, debería tenerlo en cuenta siempre que va a instalar algo)
 
 2) **Instalar Neovim** (Visitando su página oficial para hacerlo de la manera correcta según el sistema operativo: https://neovim.io/ **o** visitando su repositorio: https://github.com/neovim/neovim/wiki/Installing-Neovim)
     - **(ArchLinux)**:
     1)
-        ```bash
+        ```sh
         sudo pacman -S neovim
         ```
     2)
         **Instalar/Actualizar Python3 (A su última versión)**
-        ```bash
+        ```sh
         sudo pacman -S python3
         ```
     3)
         **Instalar el módulo de Python para Vim:**
-        ```bash
+        ```sh
         sudo pacman -S python-pynvim
         ```
     4)
         **Instalar PIP**
         *(python3)*
-        ```bash
+        ```sh
         sudo pacman -S python-pip
         ```
         *(python2)*
-        ```bash
+        ```sh
         sudo pacman -S python2-pip
         ```
     5)
         >En lo posible queremos evitar esas líneas rojas feas que aparecen cuando hay errores, muchas veces me he encontrado con lo siguiente: **No "python3" provider found. Run :checkhealth provider**
         ######
         Asi que en la terminal ingresaremos:
-        ```bash
+        ```sh
         python3 -m pip install --user --upgrade pynvim
         ```
     6)  **Instalar curl**
         Puede que NO tenga instalado/actualizado curl, aunque sería muy raro al ser un usuario de ArchLinux, en ese caso ingresaremos lo siguiente en la terminal:
-        ```bash
+        ```sh
         sudo pacman -S curl
         ```
     7)  **Instalar NVM (Node Version Manager)**
         - Instalaremos primero nodejs y npm:
-            ```bash
+            ```sh
             sudo pacman -S nodejs npm
             ```
         - Ahora revisaremos cual versión es la última de nodejs (LTS)
-            ```bash
+            ```sh
             nvm ls
             ```
         - Instalamos la última versión que nos aparece como la actual (LTS)
-            ```bash
+            ```sh
             nvm install <version>
             ```
             >💡 En caso de tener una versión actual no LTS en uso (la versión no estable) Instale la LTS y mediante el siguiente comando escoga la LTS
-            ```bash
+            ```sh
             nvm use <versionLTS>
             ```
     8)  **Instalar Ripgrep**
@@ -67,65 +63,69 @@
         ![ImageDeTelescope](https://camo.githubusercontent.com/3d59e34d1f406890adf620546d3d97017ce0aacda034b1788c66fa872f192134/68747470733a2f2f692e696d6775722e636f6d2f5454546a6136742e676966)
         Pues este Plugin necesita unas pocas dependencias:
         - [Ripgrep](https://github.com/BurntSushi/ripgrep):
-            ```bash
+            ```sh
             sudo pacman -S ripgrep
             ```
         - [fd](https://github.com/sharkdp/fd#installation):
-            ```bash
+            ```sh
             sudo pacman -S fd
             ```
         - [Tree-sitter](https://pypi.org/project/tree-sitter/):
             Mediante PIP
-            ```bash
+            ```sh
             pip3 install tree_sitter
             ```
     9)  **Instalar yarn**
-        ```bash
+        ```sh
         sudo pacman -S yarn
         ```
     10) **Instalar [Lazygit](https://github.com/jesseduffield/lazygit)** (Administrador de git)
-        ```bash
+        ```sh
         sudo pacman -S lazygit
         ```
     11) **Instalar [Glow](https://github.com/charmbracelet/glow)** (Markdown)
         ![gifRelacionadoConGlow](https://camo.githubusercontent.com/bd591b74af8a6991894c8a84ab8d48f05ce7f66975b325d31f6954c836ddab27/68747470733a2f2f73747566662e636861726d2e73682f676c6f772f676c6f772d312e332d747261696c65722d6769746875622e676966)
-        -   ```bash
+        
+        -
+            ```sh
             pacman -S glow
             ```
         > Ingrese el comando glow dentro de la carpeta en donde se encuentran sus archivos .md para visualizarlos 
  
-#
-## Clonar el [repositorio](https://github.com/spavim/spaVim)
+
+### Clonar el [repositorio](https://github.com/spavim/spaVim)
 - Vaya a su carpeta .config
-    ```bash
+    ```sh
     cd .config
     ```
 - Ingrese a la carpeta nvim, si NO la tiene creada; pues créela
-    ```bash
+    ```sh
     cd nvim
     ```
 - Clone el repositorio allí
-    ```bash
-    git clone https://github.com/spavim/spaVim.git
-    ```
-- Ingrese a la carpeta spaVim
-    ```bash
-    cd spaVim
-    ```
+    *Incluyendo el punto final*
+    -   HTTPS
+        ```sh
+        https://github.com/spavim/spaVim.git .
+        ```
+    -   SSH
+        ```sh
+        git@github.com:spavim/spaVim.git .
+        ```
 - Ingrese mediante neovim a su archivo init.vim
-    ```vim
+    ```sh
     nvim init.vim
     ```
 - En modo comandos, instale los plugins:
-    ```bash
+    ```sh
     :PlugInstall
     ```
 - Salga del editor:
-    ```bash
+    ```sh
     :wq
     ```
 >🎉 Ahora ingrese de nuevo al editor y disfrute de ***[spaVim](https://github.com/spavim/spaVim)*** 🎉
 
 **Le recomiendo instalar la fuente [Cascadia Code](https://github.com/microsoft/cascadia-code/releases) (CascadiaCodePLBold) y un tamaño de 10px en la configuración de su terminal**
-#
+
 En caso de errores post-instalación vaya a **[errores](https://github.com/spavim/spaVim/blob/main/Errors/Errors.md)**, en donde posiblemente encontrará el suyo, en caso contrario **[formúlelo aquí](https://github.com/spavim/spaVim/discussions/categories/errors)** para que los demás o el propio owner del repositorio puedan ayudarlo

--- a/Guides/guideUbuntuSpaVim.md
+++ b/Guides/guideUbuntuSpaVim.md
@@ -1,101 +1,126 @@
 # Documentación para instalar spaVim en Ubuntu
 >Tome este manual como un complemento para que su editor funcione correctamente, ya que puede omitirlo pero a largo o corto plazo le va a pedir dependencias o requisitos adicionales que ni usted mismo logrará encontrar, o puede que si, pero mejor instalarlos ahora mismo.
 
->Si el proceso de instalación le parece muy tedioso, **no lo instale**. Las cosas no deberían de hacersen tan complicadas, pero en ocasiones como en nuestro caso debemos sentarnos a configurar todo nuestro entorno de trabajo por complejo o simple que parezca.
-
->No se abrume por la posible "complejidad" de información que encontrará, porque esto solo será el abre-bocas hacia  el manual de su uso y sus comandos hahaha
-
 1) **Actualizar el sistema** (Aparte de ser necesario, debería tenerlo en cuenta siempre que va a instalar algo)
 
 2) **Instalar Neovim** (Visitando su página oficial para hacerlo de la manera correcta según el sistema operativo: https://neovim.io/ **o** visitando su repositorio: https://github.com/neovim/neovim/wiki/Installing-Neovim)
     - **(Ubuntu)**:
     1)
-        ```bash
+        ```sh
         sudo apt install neovim
         ```
     2)
         **Instalar el soporte para Python**
-        ```bash
+        ```sh
         sudo apt install python3-neovim
         ```
     3)
         **Instalar el software para las propiedades:**
         Neovim se ha agregado a un "Archivo de paquete personal" PPA, que le permite escoger entre la version [estable](https://launchpad.net/~neovim-ppa/+archive/ubuntu/stable) o la [inestable](https://launchpad.net/~neovim-ppa/+archive/ubuntu/unstable)
-        ```bash
+        
+        ```sh
         sudo apt-get install software-properties-common
         ```
+        
         >En caso de que el comando anterior no funcione a causa de que su Ubuntu no esta en la última versión, entonces ingresé el siguiente:
-        ```bash
+        ```sh
         sudo apt-get install python-software-properties
         ```
+    
     4)  **Ingrese los siguientes comandos:**
-        -   ```bash
+    
+        -
+            ```sh
             sudo add-apt-repository ppa:neovim-ppa/stable
             ```
-        -   ```bash
+        
+        -   
+            ```sh
             sudo apt-get update
             ```
-        -   ```bash
+        
+        -   
+            ```sh
             sudo apt-get install neovim
             ```
     4)
         **Instalar PIP/Los requisitos previos para los módulos de Python**
         *(python3)*
-        ```bash
+        
+        ```sh
         sudo apt-get install python3-dev python3-pip
         ```
+        
         *(python2)*
-        ```bash
+        
+        ```sh
         sudo apt-get install python-dev python-pip
         ```
+        
         >En caso de estar utilizando una version anterior de Ubuntu, entonces ingrese los siguientes comandos (**SOLO EN CASO DE QUE LOS ANTERIORES COMANDOS NO HAYAN FUNCIONADO**):
-        -   ```bash
+        
+        -
+            ```sh
             sudo apt-get install python-dev python-pip python3-dev
             ```
-        -   ```bash
+        
+        -
+            ```sh
             sudo apt-get install python3-setuptools
             ```
-        -   ```bash
+        
+        -
+            ```sh
             sudo easy_install3 pip
             ```
     5)
         >En lo posible queremos evitar esas líneas rojas feas que aparecen cuando hay errores, muchas veces me he encontrado con lo siguiente: **No "python3" provider found. Run :checkhealth provider**
         ######
         Asi que en la terminal ingresaremos:
-        ```bash
+        ```sh
         python3 -m pip install --user --upgrade pynvim
         ```
     6)  **Instalar curl**
-        Puede que NO tenga instalado/actualizado curl, aunque sería muy raro al ser un usuario de ArchLinux, en ese caso ingresaremos lo siguiente en la terminal:
-        ```bash
+        Puede que NO tenga instalado/actualizado curl, en ese caso ingresaremos lo siguiente en la terminal:
+        ```sh
         sudo apt install curl
         ```
+    
     7)  **Instalar NVM (Node Version Manager)**
-        -   ```bash
-            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+        
+        -
+            ```sh
+            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | sh
             ```
+        
         -   Ahora vamos a activar la variable de entorno para NVM con el siguiente comando:
-            ```bash
-            source ~/.bashrc
+            
+            ```sh
+            source ~/.shrc
             ```
+        
         -   Verificamos que nvm este instalado:
-            ```bash
+            
+            ```sh
             nvm --version
             ```
+        
         - Instalaremos nodejs mediante nvm:
-            ```bash
+            ```sh
             nvm install node
             ```
             > **Pero** nos instalará la versión actual NO estable, asi que revisaremos que versión LTS es la última con el siguiente comando:
-            ```bash
+        
+            ```sh
             nvm ls
             ```
             e instalaremos esa versión:
-            ```bash
+            ```sh
             nvm install <versionLTS>
             ```
         -   >💡 Al instalar de esta manera nodejs, tenemos dos versiones de el mismo (la actual NO estable, y la LTS) asi que debemos decirle a nvm en caso de no haberlo hecho antes; que usaremos la versión LTS:
-            ```bash
+            
+            ```sh
             nvm use <versionLTS>
             ```
     8)  **Instalar Ripgrep**
@@ -103,104 +128,127 @@
         ![ImageDeTelescope](https://camo.githubusercontent.com/3d59e34d1f406890adf620546d3d97017ce0aacda034b1788c66fa872f192134/68747470733a2f2f692e696d6775722e636f6d2f5454546a6136742e676966)
         Pues este Plugin necesita unas pocas dependencias:
         - [Ripgrep](https://github.com/BurntSushi/ripgrep):
-            ```bash
+            
+            ```sh
             sudo apt install ripgrep
             ```
+        
         - [fd](https://github.com/sharkdp/fd#installation):
-            ```bash
+            
+            ```sh
             sudo apt install fd-find
             ```
+        
         - [Tree-sitter](https://pypi.org/project/tree-sitter/):
             Mediante PIP
-            ```bash
+            
+            ```sh
             pip3 install tree_sitter
             ```
+    
     9)  **Instalar yarn**
-        ```bash
+        
+        ```sh
         sudo apt install yarn
         ```
+    
     10) **Instalar [Lazygit](https://github.com/jesseduffield/lazygit)** (Administrador de git)
         
-        -   ```bash
+        -
+            ```sh
             LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[0-35.]+')
             ```
 
 
-        -   ```bash
+        -
+            ```sh
             curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
             ```
 
 
-        -   ```bash
+        -
+            ```sh
             sudo tar xf lazygit.tar.gz -C /usr/local/bin lazygit
             ```
 
 
-        -   ```bash
+        -
+            ```sh
             lazygit --version
             ```
 
 
-        -   ```bash
+        -
+            ```sh
             rm -rf lazygit.tar.gz
             ```
 
 
-        -   ```bash
+        -
+            ```sh
             lazygit
             ```
 
 
             En caso de querer desinstalar Lazygit:
-        -   ```bash
+        -
+            ```sh
             sudo rm -rf /usr/local/bin/lazygit
             ```
 
             En esta **[API](https://api.github.com/repos/jesseduffield/lazygit/releases/latest)** se encontrará la última versión de Lazygit, en lo posible el Owner del repositorio se encargará de actualizarlo.
-
+            
+            <br>
         
     11) **Instalar [Glow](https://github.com/charmbracelet/glow)** (Markdown)
         ![gifRelacionadoConGlow](https://camo.githubusercontent.com/bd591b74af8a6991894c8a84ab8d48f05ce7f66975b325d31f6954c836ddab27/68747470733a2f2f73747566662e636861726d2e73682f676c6f772f676c6f772d312e332d747261696c65722d6769746875622e676966)
-        -   ```bash
+        
+        -
+            ```sh
             echo 'deb [trusted=yes] https://repo.charm.sh/apt/ /' | sudo tee /etc/apt/sources.list.d/charm.list
             ```
-        -   ```bash
+        
+        -
+            ```sh
             sudo apt update && sudo apt install glow
             ```
         > Ingrese el comando glow dentro de la carpeta en donde se encuentran sus archivos .md para visualizarlos 
         
-#
-## Clonar el [repositorio](https://github.com/spavim/spaVim)
+
+### Clonar el [repositorio](https://github.com/spavim/spaVim)
 - Vaya a su carpeta .config
-    ```bash
+    
+    ```sh
     cd .config
     ```
 - Ingrese a la carpeta nvim, si NO la tiene creada; pues créela
-    ```bash
+    ```sh
     cd nvim
     ```
 - Clone el repositorio allí
-    ```bash
-    git clone https://github.com/spavim/spaVim.git
-    ```
-- Ingrese a la carpeta spaVim
-    ```bash
-    cd spaVim
-    ```
+    *Incluyendo el punto final*
+    -   HTTPS
+        ```sh
+        https://github.com/spavim/spaVim.git .
+        ```
+    -   SSH
+        ```sh
+        git@github.com:spavim/spaVim.git .
+        ```
 - Ingrese mediante neovim a su archivo init.vim
-    ```vim
+    ```sh
     nvim init.vim
     ```
 - En modo comandos, instale los plugins:
-    ```bash
+    ```sh
     :PlugInstall
     ```
 - Salga del editor:
-    ```bash
+    ```sh
     :wq
     ```
 >🎉 Ahora ingrese de nuevo al editor y disfrute de ***[spaVim](https://github.com/spavim/spaVim)*** 🎉
 
 **Le recomiendo instalar la fuente [Cascadia Code](https://github.com/microsoft/cascadia-code/releases) (CascadiaCodePLBold) y un tamaño de 10px en la configuración de su terminal**
-#
+
 En caso de errores post-instalación vaya a **[errores](https://github.com/spavim/spaVim/blob/main/Errors/Errors.md)**, en donde posiblemente encontrará el suyo, en caso contrario **[formúlelo aquí](https://github.com/spavim/spaVim/discussions/categories/errors)** para que los demás o el propio owner del repositorio puedan ayudarlo

--- a/README.md
+++ b/README.md
@@ -33,11 +33,7 @@ Antes de revisar dichas guías de **[instalación](#container-distros)**, tómes
 </div>
 
 <div align="center" class="sistemaOperativo">
-<<<<<<< HEAD
   <h2 id="container-distros">Guías de instalación terminadas</h2>
-=======
-  <h2 id="content-distros">Guías de instalación terminadas</h2>
->>>>>>> 1397f007d6c248ee553ea8c99eea5a7fb39d51aa
   <p><b>¡NO!</b> clone el repositorio de inmediato, dentro de las guías de instalación se encuentra la manera correcta de hacerlo</p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Antes de revisar dichas guías de **[instalación](#container-distros)**, tómes
 
 <div align="center" class="sistemaOperativo">
   <h2 id="container-distros">Guías de instalación terminadas</h2>
+  <p><b>¡NO!</b> clone el repositorio de inmediato, dentro de las guías de instalación se encuentra la manera correcta de hacerlo</p>
 </div>
 
 <div align="center">


### PR DESCRIPTION
**Cambios debidos a una clonación más directa ignorando la carpeta remota y extrayendo solo los archivos**
- [x] Corregir código integrado en los archivos markdown en base a la instalación de dependencias
- [x] Actualizar el enlace redireccionado directamente al apartado de instalación para distribuciones linux
- [x] Agregar mensaje sobre como clonar correctamente el repositorio